### PR TITLE
feat: add root alias support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: ['babel-preset-expo'],
+  plugins: [
+    ['module-resolver', { alias: { '@': './' } }]
+  ]
+};

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,9 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.alias = {
+  '@': './',
+};
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add babel module-resolver alias for root
- configure metro alias for `@`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb8db70bc8331919de36099b2297c