### PR TITLE
Fix missing Babel module resolver

### DIFF
--- a/babel-plugin-module-resolver.js
+++ b/babel-plugin-module-resolver.js
@@ -1,0 +1,42 @@
+module.exports = function ({ types: t }) {
+  function resolvePath(value, alias) {
+    if (!alias) return null;
+    for (const key of Object.keys(alias)) {
+      const target = alias[key];
+      if (value === key || value.startsWith(key + '/')) {
+        return target + value.slice(key.length);
+      }
+    }
+    return null;
+  }
+
+  function updateSource(node, alias) {
+    if (!node || node.type !== 'StringLiteral') return;
+    const resolved = resolvePath(node.value, alias);
+    if (resolved) {
+      node.value = resolved;
+    }
+  }
+
+  return {
+    name: 'local-module-resolver',
+    visitor: {
+      ImportDeclaration(path, state) {
+        updateSource(path.node.source, state.opts.alias);
+      },
+      ExportNamedDeclaration(path, state) {
+        updateSource(path.node.source, state.opts.alias);
+      },
+      ExportAllDeclaration(path, state) {
+        updateSource(path.node.source, state.opts.alias);
+      },
+      CallExpression(path, state) {
+        const callee = path.get('callee');
+        if (callee.isIdentifier({ name: 'require' })) {
+          const arg = path.node.arguments[0];
+          updateSource(arg, state.opts.alias);
+        }
+      }
+    }
+  };
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,8 @@
+const moduleResolver = require('./babel-plugin-module-resolver');
+
 module.exports = {
   presets: ['babel-preset-expo'],
   plugins: [
-    ['module-resolver', { alias: { '@': './' } }]
+    [moduleResolver, { alias: { '@': './' } }]
   ]
 };


### PR DESCRIPTION
## Summary
- add in-repo Babel plugin to handle `@` alias
- use the new plugin in Babel config to remove missing dependency error

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd95a1ae483319d0ecf00d58adfef