### PR TITLE
fix alias resolution

### DIFF
--- a/babel-plugin-module-resolver.js
+++ b/babel-plugin-module-resolver.js
@@ -1,18 +1,26 @@
-module.exports = function ({ types: t }) {
-  function resolvePath(value, alias) {
+const path = require('path');
+
+module.exports = function () {
+  function resolvePath(value, alias, filename) {
     if (!alias) return null;
     for (const key of Object.keys(alias)) {
       const target = alias[key];
       if (value === key || value.startsWith(key + '/')) {
-        return target + value.slice(key.length);
+        const absoluteTarget = path.resolve(process.cwd(), target);
+        const absolutePath = path.join(absoluteTarget, value.slice(key.length));
+        let relativePath = path.relative(path.dirname(filename), absolutePath);
+        if (!relativePath.startsWith('.')) {
+          relativePath = './' + relativePath;
+        }
+        return relativePath;
       }
     }
     return null;
   }
 
-  function updateSource(node, alias) {
+  function updateSource(node, alias, filename) {
     if (!node || node.type !== 'StringLiteral') return;
-    const resolved = resolvePath(node.value, alias);
+    const resolved = resolvePath(node.value, alias, filename);
     if (resolved) {
       node.value = resolved;
     }
@@ -22,19 +30,19 @@ module.exports = function ({ types: t }) {
     name: 'local-module-resolver',
     visitor: {
       ImportDeclaration(path, state) {
-        updateSource(path.node.source, state.opts.alias);
+        updateSource(path.node.source, state.opts.alias, state.file.opts.filename);
       },
       ExportNamedDeclaration(path, state) {
-        updateSource(path.node.source, state.opts.alias);
+        updateSource(path.node.source, state.opts.alias, state.file.opts.filename);
       },
       ExportAllDeclaration(path, state) {
-        updateSource(path.node.source, state.opts.alias);
+        updateSource(path.node.source, state.opts.alias, state.file.opts.filename);
       },
       CallExpression(path, state) {
         const callee = path.get('callee');
         if (callee.isIdentifier({ name: 'require' })) {
           const arg = path.node.arguments[0];
-          updateSource(arg, state.opts.alias);
+          updateSource(arg, state.opts.alias, state.file.opts.filename);
         }
       }
     }

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,6 +3,6 @@ const moduleResolver = require('./babel-plugin-module-resolver');
 module.exports = {
   presets: ['babel-preset-expo'],
   plugins: [
-    [moduleResolver, { alias: { '@': './' } }]
+    [moduleResolver, { alias: { '@': '.' } }]
   ]
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -3,7 +3,7 @@ const { getDefaultConfig } = require('expo/metro-config');
 const config = getDefaultConfig(__dirname);
 
 config.resolver.alias = {
-  '@': './',
+  '@': '.',
 };
 
 module.exports = config;


### PR DESCRIPTION
## Summary
- ensure module resolver alias maps `@` to project root without extra slashes
- sync Metro resolver alias with Babel config

## Testing
- `npm run build:web` *(fails: Unable to resolve module ./components/LanguageSelector from /workspace/Nick_Translator/app/(tabs)/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdd0a77288331bfaf8cdd247b7b68