### PR TITLE
fix: call frameworkReady once using globalThis

### DIFF
--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -1,13 +1,11 @@
 import { useEffect } from 'react';
 
 declare global {
-  interface Window {
-    frameworkReady?: () => void;
-  }
+  var frameworkReady: (() => void) | undefined;
 }
 
 export function useFrameworkReady() {
   useEffect(() => {
-    window.frameworkReady?.();
-  });
+    globalThis.frameworkReady?.();
+  }, []);
 }


### PR DESCRIPTION
## Summary
- use `globalThis` to invoke `frameworkReady`
- trigger `frameworkReady` only on initial mount

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed during expo lint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe453de548331b287cfecbcc540ee