### PR TITLE
fix: await Google sign out check

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -119,7 +119,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       await signOut(auth);
       await SecureStore.deleteItemAsync('userToken');
-      if (GoogleSignin.hasPreviousSignIn()) {
+      if (await GoogleSignin.hasPreviousSignIn()) {
         await GoogleSignin.signOut();
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- await Google sign-in status before signing out

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68bbe460398883319a0521226fac67f7