### PR TITLE
Fix interval typing in speech recognition hook

### DIFF
--- a/hooks/useSpeechRecognition.ts
+++ b/hooks/useSpeechRecognition.ts
@@ -21,7 +21,9 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
   const [transcript, setTranscript] = useState('');
   const [confidence, setConfidence] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [simulationInterval, setSimulationInterval] = useState<NodeJS.Timeout | null>(null);
+  const [simulationInterval, setSimulationInterval] = useState<ReturnType<typeof setInterval> | null>(
+    null,
+  );
 
   const startListening = () => {
     setIsListening(true);


### PR DESCRIPTION
## Summary
- update the speech recognition hook to store the interval handle using ReturnType<typeof setInterval>
- keep cleanup logic compatible with DOM interval typing to avoid depending on @types/node

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dea0207cdc8331b880b369dfeb6920