### PR TITLE
Fix Firebase auth persistence import for React Native

### DIFF
--- a/firebase.config.ts
+++ b/firebase.config.ts
@@ -1,5 +1,5 @@
 import { initializeApp, type FirebaseApp } from 'firebase/app';
-import { initializeAuth, getReactNativePersistence, type Auth } from 'firebase/auth';
+import { initializeAuth, getReactNativePersistence, type Auth } from 'firebase/auth/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const firebaseConfig = {


### PR DESCRIPTION
## Summary
- update Firebase auth persistence import to use the React Native entrypoint

## Testing
- npm run lint (fails: ESLint is not configured for this project)

------
https://chatgpt.com/codex/tasks/task_e_68dea2aa6e888331b0fbbe976ab3252c